### PR TITLE
NEDS-62 Enable Peppol identifiers in plugin user name

### DIFF
--- a/Domibus-MSH-angular/src/app/pluginuser/support/pluginuser.service.ts
+++ b/Domibus-MSH-angular/src/app/pluginuser/support/pluginuser.service.ts
@@ -15,8 +15,8 @@ export class PluginUserService {
 
   public static passwordPattern = '^(?=.*[A-Z])(?=.*[ !#$%&\'()*+,-./:;<=>?@\\[^_`{|}~\\\]"])(?=.*[0-9])(?=.*[a-z]).{8,32}$';
 
-  public static originalUserPattern = 'urn:oasis:names:tc:ebcore:partyid\\-type:[a-zA-Z0-9_:-]+:[a-zA-Z0-9_:-]+';
-  public static originalUserPatternMessage = 'You should follow the rule: urn:oasis:names:tc:ebcore:partyid-type:[unregistered]:[corner]';
+  public static originalUserPattern = '(urn:oasis:names:tc:ebcore:partyid\\-type|iso6523\\-actorid\\-upis):[a-zA-Z0-9_:-]+:[a-zA-Z0-9_:-]+';
+  public static originalUserPatternMessage = 'You should follow the rule 1) urn:oasis:names:tc:ebcore:partyid-type:[unregistered]:[corner] OR 2) iso6523-actorid-upis::[country_code]:[global_location_number]';
   public static originalUserRequiredMessage = 'Original user field is required!';
 
   public static certificateIdPattern = 'CN=[a-zA-Z0-9_]+,O=[a-zA-Z0-9_]+,C=[a-zA-Z]{2}:[a-zA-Z0-9]+';


### PR DESCRIPTION
- Update validation of the Original User field in Plugin User view to support Peppol identifiers.
- Update error message that is shown when the value doesn't pass validation.

JIRA: https://jira.niis.org/browse/NEDS-62