### PR TITLE
NEDS-98 Update vulnerable dependencies

### DIFF
--- a/harmony-pom.xml
+++ b/harmony-pom.xml
@@ -112,7 +112,7 @@
         <guava.version>28.0-jre</guava.version>
         <joda.version>2.4</joda.version>
         <findbugs.version>3.0.2</findbugs.version>
-        <opencsv.version>5.0</opencsv.version>
+        <opencsv.version>5.7.1</opencsv.version>
         <gson.version>2.8.9</gson.version>
         <javaee-api.version>8.0.1</javaee-api.version>
         <junit.version>4.12</junit.version>


### PR DESCRIPTION
- Update OpenCSV to the latest version to get rid of the commons-text vulnerability.

JIRA: https://nordic-institute.atlassian.net/browse/NEDS-98