### PR TITLE
NEDS-123: use SoapUI plugin free version instead of PRO

### DIFF
--- a/Core/Domibus-MSH-soapui-tests/pom.xml
+++ b/Core/Domibus-MSH-soapui-tests/pom.xml
@@ -18,6 +18,7 @@
         <!-- the soap ui specific dependencies -->
         <com.smartbear.soapui.version>5.1.2</com.smartbear.soapui.version>
         <org.codehaus.groovy.version>2.9.2-01</org.codehaus.groovy.version>
+        <org.codehaus.groovy.backports.compat.version>2.4.5</org.codehaus.groovy.backports.compat.version>
         <org.codehaus.groovy.eclipse-batch.version>2.5.13-01</org.codehaus.groovy.eclipse-batch.version>
         <org.apache.activemq.version>5.16.5</org.apache.activemq.version>
 
@@ -58,6 +59,16 @@
             <artifactId>activemq-broker</artifactId>
             <version>${org.apache.activemq.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>${mysql.connector.java.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-backports-compat23</artifactId>
+            <version>${org.codehaus.groovy.backports.compat.version}</version>
+        </dependency>
 
     </dependencies>
 
@@ -84,6 +95,40 @@
                 </dependencies>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>src/main/soapui/lib</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
+                            <finalName>${project.artifactId}-${project.version}-external-dependencies</finalName>
+                            <outputName>${project.artifactId}-${project.version}-external-dependencies.jar</outputName>
+                            <outputDirectory>src/main/soapui/lib</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.groovy</groupId>
                 <artifactId>groovy-eclipse-compiler</artifactId>
                 <version>${org.codehaus.groovy.version}</version>
@@ -104,7 +149,7 @@
                     </plugin>
                     <plugin>
                         <groupId>com.smartbear.soapui</groupId>
-                        <artifactId>soapui-pro-maven-plugin</artifactId>
+                        <artifactId>soapui-maven-plugin</artifactId>
                         <version>${com.smartbear.soapui.version}</version>
                         <executions>
                             <execution>

--- a/Tomcat/Domibus-MSH-tomcat/pom.xml
+++ b/Tomcat/Domibus-MSH-tomcat/pom.xml
@@ -363,7 +363,7 @@
         <plugins>
             <plugin>
                 <groupId>com.smartbear.soapui</groupId>
-                <artifactId>soapui-pro-maven-plugin</artifactId>
+                <artifactId>soapui-maven-plugin</artifactId>
                 <version>5.1.2</version>
                 <executions>
                     <execution>


### PR DESCRIPTION
Substitute SoapUI plugin PRO version with a free version and provide compiled groovy test files with some additional missing dependencies as JAR file, so that the integration tests would not fail.