### PR TITLE
NEDS-185: Add upstream version number to info endpoint.

### DIFF
--- a/Core/Domibus-MSH-angular/src/app/common/appinfo/domibusinfo.ts
+++ b/Core/Domibus-MSH-angular/src/app/common/appinfo/domibusinfo.ts
@@ -1,5 +1,5 @@
 export class DomibusInfo {
 
-  constructor(public version: string, public versionNumber: string) {
+  constructor(public version: string, public versionNumber: string, public upstreamVersionNumber: string) {
   }
 }

--- a/Core/Domibus-MSH-angular/src/app/common/page-helper/page-helper.component.ts
+++ b/Core/Domibus-MSH-angular/src/app/common/page-helper/page-helper.component.ts
@@ -39,8 +39,8 @@ export class PageHelperComponent implements OnInit {
 
   private async setHelpPages() {
     const domibusInfo = await this.domibusInfoService.getDomibusInfo();
-    const MAIN_HELP_PAGE = `https://edelivery.digital/`;
-    const VERSION_SPECIFIC_PAGE = `#harmony-ap-v${domibusInfo.versionNumber}-help-`;
+    const MAIN_HELP_PAGE = `https://ec.europa.eu/digital-building-blocks/wikis/display/DIGITAL/Domibus+v${domibusInfo.upstreamVersionNumber}+Admin+Console+Help`;
+    const VERSION_SPECIFIC_PAGE = `#Domibusv${domibusInfo.upstreamVersionNumber}AdminConsoleHelp-`;
 
     const routes = this.router.config;
     routes.forEach(route => {

--- a/Core/Domibus-MSH/pom.xml
+++ b/Core/Domibus-MSH/pom.xml
@@ -17,6 +17,7 @@
         <endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <timestamp>${maven.build.timestamp}</timestamp>
+        <upstream.version>5.1.4</upstream.version>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
 
         <projectFile>${project.basedir}/src/test/resources/soapUI/AS4-test-guide-soapui-project.xml</projectFile>

--- a/Core/Domibus-MSH/src/main/java/eu/domibus/core/property/DomibusVersionService.java
+++ b/Core/Domibus-MSH/src/main/java/eu/domibus/core/property/DomibusVersionService.java
@@ -34,6 +34,7 @@ public class DomibusVersionService {
             versionProps.load(inputStream);
             LOG.info("=========================================================================================================");
             LOG.info("|         " + getDisplayVersion() + "        |");
+            LOG.info("|         Upstream version [" + getUpstreamVersion() + "]");
             LOG.info("=========================================================================================================");
         } catch (Exception ex) {
             LOG.warn("Error loading version properties", ex);

--- a/Core/Domibus-MSH/src/main/java/eu/domibus/core/property/DomibusVersionService.java
+++ b/Core/Domibus-MSH/src/main/java/eu/domibus/core/property/DomibusVersionService.java
@@ -50,6 +50,10 @@ public class DomibusVersionService {
         return versionNumber;
     }
 
+    public String getUpstreamVersion() {
+      return versionProps.getProperty("Upstream-Version");
+    }
+
     public String getArtifactName() {
         return versionProps.getProperty("Artifact-Name");
     }

--- a/Core/Domibus-MSH/src/main/java/eu/domibus/web/rest/ApplicationResource.java
+++ b/Core/Domibus-MSH/src/main/java/eu/domibus/web/rest/ApplicationResource.java
@@ -77,6 +77,7 @@ public class ApplicationResource {
         final DomibusInfoRO domibusInfoRO = new DomibusInfoRO();
         domibusInfoRO.setVersion(domibusVersionService.getDisplayVersion());
         domibusInfoRO.setVersionNumber(domibusVersionService.getVersionNumber());
+        domibusInfoRO.setUpstreamVersionNumber(domibusVersionService.getUpstreamVersion());
         return domibusInfoRO;
     }
 

--- a/Core/Domibus-MSH/src/main/java/eu/domibus/web/rest/ro/DomibusInfoRO.java
+++ b/Core/Domibus-MSH/src/main/java/eu/domibus/web/rest/ro/DomibusInfoRO.java
@@ -12,6 +12,8 @@ public class DomibusInfoRO implements Serializable {
 
     private String versionNumber;
 
+    private String upstreamVersionNumber;
+
     public String getVersion() {
         return version;
     }
@@ -26,5 +28,13 @@ public class DomibusInfoRO implements Serializable {
 
     public void setVersionNumber(String versionNumber) {
         this.versionNumber = versionNumber;
+    }
+
+    public String getUpstreamVersionNumber() {
+      return upstreamVersionNumber;
+    }
+
+    public void setUpstreamVersionNumber(String upstreamVersionNumber) {
+      this.upstreamVersionNumber = upstreamVersionNumber;
     }
 }

--- a/Core/Domibus-MSH/src/main/resources/config/version.properties
+++ b/Core/Domibus-MSH/src/main/resources/config/version.properties
@@ -1,3 +1,4 @@
 Artifact-Version=${project.version}
 Artifact-Name=${project.artifactId}
 Build-Time=${timestamp}
+Upstream-Version=${upstream.version}


### PR DESCRIPTION
Creates a new property in the MSH pom, this variable is shown in the info endpoint. Example:

```
{
    "version": "harmony-MSH Version [2.4.0] Build-Time [2024-05-27 11:34|Coordinated Universal Time]",
    "versionNumber": "2.4.0",
    "upstreamVersionNumber": "5.1.4"
}
```

This new property is then used in the UI to open the right version of the help pages