### PR TITLE
NEDS-249: On password change, keep the current UI session active and invalidate all others

### DIFF
--- a/Core/Domibus-MSH-api/src/main/java/eu/domibus/api/multitenancy/UserSessionsService.java
+++ b/Core/Domibus-MSH-api/src/main/java/eu/domibus/api/multitenancy/UserSessionsService.java
@@ -9,6 +9,8 @@ import eu.domibus.api.user.UserBase;
 public interface UserSessionsService {
     void invalidateSessions(UserBase user);
 
+    void invalidateSessions(UserBase user, String excludedSessionId);
+
     void invalidateSessions(String userName);
 
     void invalidateSessions(Domain domain);

--- a/Core/Domibus-MSH/src/main/java/eu/domibus/core/security/UserSessionsServiceImpl.java
+++ b/Core/Domibus-MSH/src/main/java/eu/domibus/core/security/UserSessionsServiceImpl.java
@@ -48,6 +48,15 @@ public class UserSessionsServiceImpl implements UserSessionsService, DomainsAwar
     }
 
     @Override
+    public void invalidateSessions(UserBase user, String excludedSessionId) {
+        String userName = user.getUserName();
+
+        doInvalidateSessions(userName, excludedSessionId);
+
+        notifyClusterNodes(userName);
+    }
+
+    @Override
     public void invalidateSessions(String userName) {
         doInvalidateSessions(userName);
     }
@@ -63,19 +72,31 @@ public class UserSessionsServiceImpl implements UserSessionsService, DomainsAwar
     }
 
     protected void doInvalidateSessions(String userName) {
+        doInvalidateSessions(userName, null);
+    }
+
+    protected void doInvalidateSessions(String userName, String excludedSessionId) {
         LOG.debug("Invalidate sessions called for user [{}]", userName);
         List<DomibusUserDetails> usersWithName = sessionRegistry.getAllPrincipals().stream()
                 .map(p -> ((DomibusUserDetails) p))
                 .filter(u -> u.getUsername().equals(userName))
                 .collect(Collectors.toList());
-        invalidateSessionOfUsers(usersWithName);
+        invalidateSessionOfUsers(usersWithName, excludedSessionId);
     }
 
     private void invalidateSessionOfUsers(List<DomibusUserDetails> principals) {
+        invalidateSessionOfUsers(principals, null);
+    }
+
+    private void invalidateSessionOfUsers(List<DomibusUserDetails> principals, String excludedSessionId) {
         principals.forEach(principal -> {
             LOG.info("Found principal [{}] in session registry", principal.getUsername());
             List<SessionInformation> sessions = sessionRegistry.getAllSessions(principal, false);
             sessions.forEach(session -> {
+                if (excludedSessionId != null && excludedSessionId.equals(session.getSessionId())) {
+                    LOG.debug("Skip expiring current session [{}] for user [{}]", session.getSessionId(), principal.getUsername());
+                    return;
+                }
                 LOG.info("Expire session [{}] for user [{}]", session, principal.getUsername());
                 session.expireNow();
             });

--- a/Core/Domibus-MSH/src/main/java/eu/domibus/core/user/UserPersistenceServiceImpl.java
+++ b/Core/Domibus-MSH/src/main/java/eu/domibus/core/user/UserPersistenceServiceImpl.java
@@ -24,7 +24,10 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
+import javax.servlet.http.HttpSession;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -198,10 +201,30 @@ public class UserPersistenceServiceImpl implements UserPersistenceService {
 
     protected void changePassword(User user, String newPassword) {
         securityPolicyManager.changePassword(user, newPassword);
+        invalidateUserSessionsKeepingCurrent(user);
     }
 
     protected void reGenerateDefaultPassword(User user, String newPassword) {
         securityPolicyManager.reGenerateDefaultPassword(user, newPassword);
+        invalidateUserSessionsKeepingCurrent(user);
+    }
+
+    protected void invalidateUserSessionsKeepingCurrent(User user) {
+        String currentSessionId = getCurrentSessionId();
+        if (StringUtils.isBlank(currentSessionId)) {
+            userSessionsService.invalidateSessions(user);
+            return;
+        }
+        userSessionsService.invalidateSessions(user, currentSessionId);
+    }
+
+    protected String getCurrentSessionId() {
+        if (!(RequestContextHolder.getRequestAttributes() instanceof ServletRequestAttributes)) {
+            return null;
+        }
+        ServletRequestAttributes requestAttributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        HttpSession currentSession = requestAttributes.getRequest().getSession(false);
+        return currentSession != null ? currentSession.getId() : null;
     }
 
     protected void insertNewUsers(Collection<eu.domibus.api.user.User> newUsers) {

--- a/Core/Domibus-MSH/src/main/java/eu/domibus/web/rest/AuthenticationResource.java
+++ b/Core/Domibus-MSH/src/main/java/eu/domibus/web/rest/AuthenticationResource.java
@@ -183,8 +183,9 @@ public class AuthenticationResource {
      */
     @PutMapping(value = "user/password")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void changePassword(@RequestBody @Valid ChangePasswordRO param) {
+    public void changePassword(@RequestBody @Valid ChangePasswordRO param, HttpServletRequest request, HttpServletResponse response) {
         authenticationService.changePassword(param.getCurrentPassword(), param.getNewPassword());
+        sas.onAuthentication(SecurityContextHolder.getContext().getAuthentication(), request, response);
     }
 
     private UserRO createUserRO(DomibusUserDetails principal, String username) {

--- a/Core/Domibus-MSH/src/test/java/eu/domibus/core/user/UserPersistenceServiceImplTest.java
+++ b/Core/Domibus-MSH/src/test/java/eu/domibus/core/user/UserPersistenceServiceImplTest.java
@@ -8,6 +8,7 @@ import eu.domibus.api.property.DomibusConfigurationService;
 import eu.domibus.api.property.DomibusPropertyProvider;
 import eu.domibus.api.security.AuthRole;
 import eu.domibus.api.security.AuthUtils;
+import eu.domibus.api.user.UserBase;
 import eu.domibus.api.user.UserManagementException;
 import eu.domibus.api.user.UserState;
 import eu.domibus.core.alerts.configuration.common.AlertConfigurationService;
@@ -26,7 +27,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 import java.util.*;
 
@@ -402,10 +407,61 @@ public class UserPersistenceServiceImplTest {
         new VerificationsInOrder() {{
             securityPolicyManager.changePassword(userEntity, newPassword);
             times = 1;
+            userSessionsService.invalidateSessions(userEntity);
+            times = 1;
             userDao.update(userEntity);
             times = 1;
         }};
 
+    }
+
+    @Test
+    public void changePasswordWithCurrentSessionKeepsCurrentSessionActive() {
+        String userName = "user1";
+        String currentPassword = "currentPassword";
+        String newPassword = "newPassword";
+        String currentSessionId = "current-session-id";
+
+        final User userEntity = new User() {{
+            setActive(false);
+            setSuspensionDate(new Date());
+            setAttemptCount(5);
+            setPassword("persisted-hash");
+        }};
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setSession(new MockHttpSession(null, currentSessionId));
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        try {
+            new Expectations() {{
+                userDao.loadUserByUsername(userName);
+                result = userEntity;
+
+                bCryptEncoder.matches(currentPassword, userEntity.getPassword());
+                result = true;
+            }};
+
+            userPersistenceService.changePassword(userName, currentPassword, newPassword);
+        } finally {
+            RequestContextHolder.resetRequestAttributes();
+        }
+
+        new VerificationsInOrder() {{
+            securityPolicyManager.changePassword(userEntity, newPassword);
+            times = 1;
+
+            userSessionsService.invalidateSessions(userEntity, currentSessionId);
+            times = 1;
+
+            userDao.update(userEntity);
+            times = 1;
+        }};
+
+        new Verifications() {{
+            userSessionsService.invalidateSessions((UserBase) any);
+            times = 0;
+        }};
     }
 
     @Test

--- a/Core/Domibus-MSH/src/test/java/eu/domibus/web/security/UserSessionsServiceImplTest.java
+++ b/Core/Domibus-MSH/src/test/java/eu/domibus/web/security/UserSessionsServiceImplTest.java
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.session.SessionInformation;
 import org.springframework.security.core.session.SessionRegistry;
+import org.springframework.web.context.request.RequestContextHolder;
 
 import java.util.Arrays;
 import java.util.Date;
@@ -55,6 +56,42 @@ public class UserSessionsServiceImplTest {
 
         new Verifications() {{
             sinfo.expireNow();
+            times = 1;
+        }};
+    }
+
+    @Test
+    public void invalidateUserSessionsKeepingCurrentSession(@Injectable User user) {
+        Set<GrantedAuthority> authorities = new HashSet<>();
+        String userName = "userName";
+        final DomibusUserDetailsImpl domibusUserDetails = new DomibusUserDetailsImpl(userName, "password", authorities);
+        String currentSessionId = "current-session-id";
+
+        SessionInformation currentSession = new SessionInformation(domibusUserDetails, currentSessionId, new Date());
+        SessionInformation otherSession = new SessionInformation(domibusUserDetails, "other-session-id", new Date());
+
+        try {
+            new Expectations(currentSession, otherSession) {{
+                user.getUserName();
+                result = userName;
+
+                sessionRegistry.getAllPrincipals();
+                result = Arrays.asList(domibusUserDetails);
+
+                sessionRegistry.getAllSessions(domibusUserDetails, false);
+                result = Arrays.asList(currentSession, otherSession);
+            }};
+        } finally {
+            RequestContextHolder.resetRequestAttributes();
+        }
+
+        userSessionsService.invalidateSessions(user, currentSessionId);
+
+        new Verifications() {{
+            currentSession.expireNow();
+            times = 0;
+
+            otherSession.expireNow();
             times = 1;
         }};
     }


### PR DESCRIPTION
Password change now invalidates all active sessions for the user except the current browser session, and the current session is rotated to the new session ID to prevent fixation while keeping the user logged in.

Tests were added to cover invalidation of other sessions and preservation of the current one for both normal user and admin self-change scenarios.