### PR TITLE
NEDS-245: Add server-side user filtering and pagination support

### DIFF
--- a/Core/Domibus-MSH-angular/src/app/domains/domains.component.ts
+++ b/Core/Domibus-MSH-angular/src/app/domains/domains.component.ts
@@ -15,7 +15,7 @@ import {ComponentName} from '../common/component-name-decorator';
 import {ClientSortableListMixin} from '../common/mixins/sortable-list.mixin';
 import {DomainService} from '../security/domain.service';
 import {Domain} from '../security/domain';
-import { UserService } from 'app/user/support/user.service';
+import {UserSearchCriteria, UserService} from 'app/user/support/user.service';
 import { SecurityService } from 'app/security/security.service';
 import {DomibusInfoService} from "../common/appinfo/domibusinfo.service";
 
@@ -104,7 +104,11 @@ export class DomainsComponent extends mix(BaseListComponent).with(ClientPageable
           // as the notion of 'preferred domain' is not the same in this case
         } else {
           let currentUserName: string = (await this.securityService.getCurrentUserFromServer()).username;
-          let users = await this.userService.getUsers();
+
+          const criteria = new UserSearchCriteria();
+          criteria.userName = currentUserName;
+
+          let users = await this.userService.getUsers(criteria);
           let currentUser = users.find(u => u.userName == currentUserName);
           if (currentUser.domain == domain.code) {
             throw `Cannot disable the domain of the current user`;

--- a/Core/Domibus-MSH-angular/src/app/user/support/user.service.ts
+++ b/Core/Domibus-MSH-angular/src/app/user/support/user.service.ts
@@ -16,7 +16,7 @@ export class UserService {
               private domainService: DomainService) {
   }
 
-  getUsers(criteria?: UserSearchCriteria): Promise<UserResponseRO[]> {
+  getUsers(criteria: UserSearchCriteria): Promise<UserResponseRO[]> {
     return this.http.get<UserResponseRO[]>('rest/user/users', {params: this.buildSearchParams(criteria)}).toPromise();
   }
 

--- a/Core/Domibus-MSH-angular/src/app/user/support/user.service.ts
+++ b/Core/Domibus-MSH-angular/src/app/user/support/user.service.ts
@@ -1,8 +1,9 @@
 import {UserResponseRO} from './user';
 import {Injectable} from '@angular/core';
-import {HttpClient} from '@angular/common/http';
+import {HttpClient, HttpParams} from '@angular/common/http';
 import {AlertService} from '../../common/alert/alert.service';
-import {Observable} from 'rxjs/Observable';
+import {Observable} from 'rxjs';
+import {map} from 'rxjs/operators';
 import {SecurityService} from '../../security/security.service';
 import {DomainService} from '../../security/domain.service';
 
@@ -15,13 +16,15 @@ export class UserService {
               private domainService: DomainService) {
   }
 
-  getUsers(): Promise<UserResponseRO[]> {
-    return this.http.get<UserResponseRO[]>('rest/user/users').toPromise();
+  getUsers(criteria?: UserSearchCriteria): Promise<UserResponseRO[]> {
+    return this.http.get<UserResponseRO[]>('rest/user/users', {params: this.buildSearchParams(criteria)}).toPromise();
   }
 
   getUserNames(): Observable<string[]> {
-    return this.http.get<UserResponseRO[]>('rest/user/users')
-      .map((users: UserResponseRO[]) => users.map(u => u.userName))
+    const criteria = new UserSearchCriteria();
+    criteria.deleted_notSet = true;
+    return this.http.get<UserResponseRO[]>('rest/user/users', {params: this.buildSearchParams(criteria)})
+      .pipe(map((users: UserResponseRO[]) => users.map(u => u.userName)));
   }
 
   getUserRoles(): Observable<string[]> {
@@ -52,6 +55,32 @@ export class UserService {
     }
   }
 
+  private buildSearchParams(criteria: UserSearchCriteria): HttpParams {
+    const {
+      authRole,
+      userName,
+      pageStart,
+      pageSize
+    } = criteria;
+
+    let params = new HttpParams()
+        .set('pageStart', String(pageStart))
+        .set('pageSize', String(pageSize));
+
+    const deleted = criteria.deleted_notSet ? 'all' : (criteria.deleted === true).toString();
+    params = params.set('deleted', deleted);
+
+    if (authRole) {
+      params = params.set('authRole', authRole);
+    }
+
+    if (userName) {
+      params = params.set('userName', userName);
+    }
+
+    return params;
+  }
+
 }
 
 export class UserSearchCriteria {
@@ -59,6 +88,7 @@ export class UserSearchCriteria {
   userName: string;
   deleted: boolean = false;
   deleted_notSet: boolean = false;
+  pageStart: number = 0;
+  pageSize: number = -1;
   i: number = 0;
 }
-

--- a/Core/Domibus-MSH-angular/src/app/user/user.component.ts
+++ b/Core/Domibus-MSH-angular/src/app/user/user.component.ts
@@ -170,10 +170,11 @@ export class UserComponent extends mix(BaseListComponent)
   }
 
   async getUsers(): Promise<any> {
-    return this.userService.getUsers()
-      .then(async allUsers => {
-        this.allUsers = allUsers;
-        let users = allUsers.filter(this.applyFilter(this.activeFilter));
+    const userSearchCriteria = this.buildUserSearchCriteria();
+
+    return this.userService.getUsers(userSearchCriteria)
+      .then(async users => {
+        this.allUsers = users;
 
         await this.userService.checkConfiguredCorrectlyForMultitenancy(users);
 
@@ -187,20 +188,15 @@ export class UserComponent extends mix(BaseListComponent)
       });
   }
 
-  private applyFilter(filter: UserSearchCriteria) {
-    return (user) => {
-      let crit1 = true, crit2 = true, crit3 = true;
-      if (filter.userName) {
-        crit1 = user.userName === filter.userName;
-      }
-      if (!filter.deleted_notSet) {
-        crit2 = user.deleted === filter.deleted;
-      }
-      if (filter.authRole) {
-        crit3 = user.roles === filter.authRole;
-      }
-      return crit1 && crit2 && crit3;
-    }
+  private buildUserSearchCriteria(): UserSearchCriteria {
+    const { authRole, userName, deleted, deleted_notSet } = this.activeFilter || {};
+
+    return Object.assign(new UserSearchCriteria(), {
+      authRole: authRole || undefined,
+      userName: userName || undefined,
+      deleted: deleted === true,
+      deleted_notSet: deleted_notSet === true
+    });
   }
 
   private async setDomain(users: UserResponseRO[]) {

--- a/Core/Domibus-MSH/src/main/java/eu/domibus/web/rest/UserResource.java
+++ b/Core/Domibus-MSH/src/main/java/eu/domibus/web/rest/UserResource.java
@@ -96,10 +96,23 @@ public class UserResource extends BaseResource {
      * {@inheritDoc}
      */
     @GetMapping(value = {"/users"})
-    public List<UserResponseRO> getUsers() {
+    public List<UserResponseRO> getUsers(UserFilterRequestRO request) {
         LOG.debug("Retrieving users");
 
-        List<User> users = getUserService().findUsers();
+        if (request.getPageStart() < 0) {
+            request.setPageStart(0);
+        }
+
+        if (request.getPageSize() <= 0) {
+            request.setPageSize(Integer.MAX_VALUE);
+        }
+
+        List<User> users = getUserService().findUsersWithFilters(
+                request.getAuthRole(),
+                request.getUserName(),
+                request.getDeleted(),
+                request.getPageStart(),
+                request.getPageSize());
 
         return prepareResponse(users);
     }

--- a/Core/Domibus-MSH/src/test/java/eu/domibus/web/rest/UserResourceTest.java
+++ b/Core/Domibus-MSH/src/test/java/eu/domibus/web/rest/UserResourceTest.java
@@ -101,7 +101,7 @@ public class UserResourceTest {
         domainsList.add(domain);
 
         new Expectations() {{
-            userManagementService.findUsers();
+            userManagementService.findUsersWithFilters(null, null, null, 0, 10);
             result = userList;
 
             domain.getCode();
@@ -115,13 +115,65 @@ public class UserResourceTest {
         }};
 
         // When
-        List<UserResponseRO> userResponseROS = userResource.getUsers();
+        List<UserResponseRO> userResponseROS = userResource.getUsers(new UserFilterRequestRO());
         userResource.updateUsers(userResponseROS);
 
         // Then
         Assert.assertNotNull(userResponseROS);
         UserResponseRO userResponseRO = getUserResponseRO();
         Assert.assertEquals(userResponseRO, userResponseROS.get(0));
+    }
+
+    @Test
+    public void testGetUsersDelegatesFiltersAndPagination() {
+        UserFilterRequestRO request = new UserFilterRequestRO();
+        request.setAuthRole(AuthRole.ROLE_ADMIN);
+        request.setUserName("admin");
+        request.setDeleted("all");
+        request.setPageStart(2);
+        request.setPageSize(25);
+
+        final List<User> userList = new ArrayList<>();
+        final List<UserResponseRO> userResponseROList = new ArrayList<>();
+
+        new Expectations() {{
+            userManagementService.findUsersWithFilters(AuthRole.ROLE_ADMIN, "admin", "all", 2, 25);
+            result = userList;
+
+            authCoreMapper.userListToUserResponseROList(userList);
+            result = userResponseROList;
+        }};
+
+        List<UserResponseRO> userResponseROS = userResource.getUsers(request);
+
+        Assert.assertNotNull(userResponseROS);
+        Assert.assertEquals(0, userResponseROS.size());
+    }
+
+    @Test
+    public void testGetUsersNormalizesPaginationValues() {
+        UserFilterRequestRO request = new UserFilterRequestRO();
+        request.setDeleted("all");
+        request.setPageStart(-3);
+        request.setPageSize(0);
+
+        final List<User> userList = new ArrayList<>();
+        final List<UserResponseRO> userResponseROList = new ArrayList<>();
+
+        new Expectations() {{
+            userManagementService.findUsersWithFilters(null, null, "all", 0, Integer.MAX_VALUE);
+            result = userList;
+
+            authCoreMapper.userListToUserResponseROList(userList);
+            result = userResponseROList;
+        }};
+
+        List<UserResponseRO> userResponseROS = userResource.getUsers(request);
+
+        Assert.assertEquals(0, request.getPageStart());
+        Assert.assertEquals(Integer.MAX_VALUE, request.getPageSize());
+        Assert.assertNotNull(userResponseROS);
+        Assert.assertEquals(0, userResponseROS.size());
     }
 
     @Test


### PR DESCRIPTION
This change moves user filtering from the UI to the backend by introducing a filter + pagination request model for the users endpoint.

The frontend now builds a criteria object and sends it as query params instead of fetching all users and filtering client-side.

The backend endpoint accepts a filter object, normalizes pagination values, and delegates to `findUsersWithFilters(...)` to return the filtered result set.